### PR TITLE
THULLO-82:  Ignore most application properties files, except "application.properties" and "application-prod.properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,10 @@ out/
 ### VS Code ###
 .vscode/
 mySSH.pem
+
+# Ignore all application properties files
+application*.properties
+
+# Except for these two files
+!application.properties
+!application-prod.properties


### PR DESCRIPTION
Added new rules to the Gitignore file to exclude all application properties files except for "application.properties" and "application-prod.properties". This will ensure that only the necessary files are tracked in Git, reducing clutter and potential conflicts.