### PR TITLE
THULLO-100: Endpoint Implementation for Editing Task Status

### DIFF
--- a/src/main/java/com/thullo/service/BoardServiceImpl.java
+++ b/src/main/java/com/thullo/service/BoardServiceImpl.java
@@ -56,7 +56,7 @@ public class BoardServiceImpl implements BoardService {
             imageUrl = fileService.uploadFile(boardRequest.getFile(), boardRequest.getRequestUrl());
         }
         board.setImageUrl(imageUrl);
-        board.setBoardTag(generateThreeLetterWord(boardRequest.getName().toUpperCase()));
+        board.setBoardTag(generateThreeLetterWord(boardRequest.getBoardName().toUpperCase()));
 
         return getBoard(boardRepository.save(board));
     }

--- a/src/main/java/com/thullo/service/TaskService.java
+++ b/src/main/java/com/thullo/service/TaskService.java
@@ -37,8 +37,6 @@ public interface TaskService {
 
     void deleteAttachmentFromTask(String fileId, Long attachmentId);
 
-    List<Task> editStatus(StatusRequest request, String boardTag) throws ResourceNotFoundException;
-
-    List<Task> updateStatus(StatusRequest request, String boardTag) throws ResourceNotFoundException;
+    List<Task> editStatus(StatusRequest request) throws ResourceNotFoundException;
 }
 

--- a/src/main/java/com/thullo/service/TaskService.java
+++ b/src/main/java/com/thullo/service/TaskService.java
@@ -4,6 +4,7 @@ import com.thullo.data.model.Attachment;
 import com.thullo.data.model.Task;
 import com.thullo.web.exception.BadRequestException;
 import com.thullo.web.exception.ResourceNotFoundException;
+import com.thullo.web.payload.request.StatusRequest;
 import com.thullo.web.payload.request.TaskRequest;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -36,5 +37,8 @@ public interface TaskService {
 
     void deleteAttachmentFromTask(String fileId, Long attachmentId);
 
+    List<Task> editStatus(StatusRequest request, String boardTag) throws ResourceNotFoundException;
+
+    List<Task> updateStatus(StatusRequest request, String boardTag) throws ResourceNotFoundException;
 }
 

--- a/src/main/java/com/thullo/service/TaskServiceImpl.java
+++ b/src/main/java/com/thullo/service/TaskServiceImpl.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -207,31 +208,17 @@ public class TaskServiceImpl implements TaskService {
     }
 
     @Override
-    public List<Task> editStatus(StatusRequest request, String boardTag) throws ResourceNotFoundException {
-        Board board = getBoard(boardTag);
-        String previousStatus = formatStatus(request.getPreviousStatus());
-        List<Task> tasks = getAllByBoardAndStatus(board, previousStatus);
-        String currentStatus = formatStatus(request.getCurrentStatus());
-
-        for (Task task : tasks) {
-            task.setStatus(currentStatus);
-            taskRepository.save(task);
-        }
-        return getAllByBoardAndStatus(board, currentStatus);
-    }
-
-    @Override
-    public List<Task> updateStatus(StatusRequest request, String boardTag) throws ResourceNotFoundException {
-        Board board = getBoard(boardTag);
+    public List<Task> editStatus(StatusRequest request) throws ResourceNotFoundException {
         Set<String> boardRefs = request.getBoardRef();
-        String status = formatStatus(request.getCurrentStatus());
+        String status = formatStatus(request.getStatus());
 
+        List<Task> tasks = new ArrayList<>();
         for (String boardRef : boardRefs) {
             Task task = getTask(boardRef);
             task.setStatus(status);
-            taskRepository.save(task);
+            tasks.add(task);
         }
-        return getAllByBoardAndStatus(board, status);
+        return taskRepository.saveAll(tasks);
     }
 
     private List<Task> getAllByBoardAndStatus(Board board, String formattedStatus) {

--- a/src/main/java/com/thullo/web/controller/TaskController.java
+++ b/src/main/java/com/thullo/web/controller/TaskController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.validation.Valid;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -172,7 +173,7 @@ public class TaskController {
     @PutMapping("{boardTag}/edit-status")
     @PreAuthorize("@boardServiceImpl.hasBoardRole(authentication.principal.email, #boardTag) or hasRole('BOARD_' + #boardTag) or hasRole('TASK_' + #boardRef)")
     public ResponseEntity<ApiResponse> editStatus(@PathVariable String boardTag,
-                                                  @RequestBody StatusRequest status,
+                                                  @Valid @RequestBody StatusRequest status,
                                                   HttpServletRequest request) {
         try {
             status.setRequestUrl(request.getRequestURL().toString());

--- a/src/main/java/com/thullo/web/controller/TaskController.java
+++ b/src/main/java/com/thullo/web/controller/TaskController.java
@@ -169,12 +169,17 @@ public class TaskController {
         return ResponseEntity.ok(new ApiResponse(true, "Attachment is  successfully deleted"));
     }
 
-    @PutMapping("/edit-status")
+    @PutMapping("{boardTag}/edit-status")
     @PreAuthorize("@boardServiceImpl.hasBoardRole(authentication.principal.email, #boardTag) or hasRole('BOARD_' + #boardTag) or hasRole('TASK_' + #boardRef)")
-    public ResponseEntity<ApiResponse> editStatus(@RequestBody StatusRequest status,
-                                                  HttpServletRequest request) throws ResourceNotFoundException {
-        status.setRequestUrl(request.getRequestURL().toString());
-        List<Task> tasks = taskService.editStatus(status);
-        return ResponseEntity.ok(new ApiResponse(true, "Status is successfully updated", tasks));
+    public ResponseEntity<ApiResponse> editStatus(@PathVariable String boardTag,
+                                                  @RequestBody StatusRequest status,
+                                                  HttpServletRequest request) {
+        try {
+            status.setRequestUrl(request.getRequestURL().toString());
+            List<Task> tasks = taskService.editStatus(status);
+            return ResponseEntity.ok(new ApiResponse(true, "Status is successfully updated", tasks));
+        } catch (ResourceNotFoundException exception) {
+            return ResponseEntity.badRequest().body(new ApiResponse(false, exception.getMessage()));
+        }
     }
 }

--- a/src/main/java/com/thullo/web/controller/TaskController.java
+++ b/src/main/java/com/thullo/web/controller/TaskController.java
@@ -7,6 +7,7 @@ import com.thullo.security.UserPrincipal;
 import com.thullo.service.TaskService;
 import com.thullo.web.exception.BadRequestException;
 import com.thullo.web.exception.ResourceNotFoundException;
+import com.thullo.web.payload.request.StatusRequest;
 import com.thullo.web.payload.request.TaskMoveRequest;
 import com.thullo.web.payload.request.TaskRequest;
 import com.thullo.web.payload.response.ApiResponse;
@@ -167,4 +168,15 @@ public class TaskController {
         taskService.deleteAttachmentFromTask(request.getRequestURL().toString(), attachmentId);
         return ResponseEntity.ok(new ApiResponse(true, "Attachment is  successfully deleted"));
     }
+
+    @PutMapping("{boardTag}")
+    @PreAuthorize("@boardServiceImpl.hasBoardRole(authentication.principal.email, #boardTag) or hasRole('BOARD_' + #boardTag) or hasRole('TASK_' + #boardRef)")
+    public ResponseEntity<ApiResponse> editStatus(@PathVariable String boardTag,
+                                                  @RequestBody StatusRequest status,
+                                                  HttpServletRequest request) throws ResourceNotFoundException {
+        status.setRequestUrl(request.getRequestURL().toString());
+        List<Task> tasks = taskService.editStatus(status, boardTag);
+        return ResponseEntity.ok(new ApiResponse(true, "Status is successfully updated", tasks));
+    }
+
 }

--- a/src/main/java/com/thullo/web/controller/TaskController.java
+++ b/src/main/java/com/thullo/web/controller/TaskController.java
@@ -169,14 +169,12 @@ public class TaskController {
         return ResponseEntity.ok(new ApiResponse(true, "Attachment is  successfully deleted"));
     }
 
-    @PutMapping("{boardTag}")
+    @PutMapping("/edit-status")
     @PreAuthorize("@boardServiceImpl.hasBoardRole(authentication.principal.email, #boardTag) or hasRole('BOARD_' + #boardTag) or hasRole('TASK_' + #boardRef)")
-    public ResponseEntity<ApiResponse> editStatus(@PathVariable String boardTag,
-                                                  @RequestBody StatusRequest status,
+    public ResponseEntity<ApiResponse> editStatus(@RequestBody StatusRequest status,
                                                   HttpServletRequest request) throws ResourceNotFoundException {
         status.setRequestUrl(request.getRequestURL().toString());
-        List<Task> tasks = taskService.editStatus(status, boardTag);
+        List<Task> tasks = taskService.editStatus(status);
         return ResponseEntity.ok(new ApiResponse(true, "Status is successfully updated", tasks));
     }
-
 }

--- a/src/main/java/com/thullo/web/payload/request/BoardRequest.java
+++ b/src/main/java/com/thullo/web/payload/request/BoardRequest.java
@@ -13,7 +13,7 @@ import javax.validation.constraints.NotNull;
 @NoArgsConstructor
 public class BoardRequest {
     @NotBlank(message = "Board name cannot be blank")
-    private String name;
+    private String boardName;
     private String requestUrl;
     @NotNull(message = "Cover image cannot be null")
     private MultipartFile file;

--- a/src/main/java/com/thullo/web/payload/request/BoardRequest.java
+++ b/src/main/java/com/thullo/web/payload/request/BoardRequest.java
@@ -19,6 +19,5 @@ public class BoardRequest {
     private MultipartFile file;
     private String boardVisibility;     //The board visibility is set ot private by default
     private String boardTag;
-
     private String imageUrl;
 }

--- a/src/main/java/com/thullo/web/payload/request/StatusRequest.java
+++ b/src/main/java/com/thullo/web/payload/request/StatusRequest.java
@@ -9,8 +9,7 @@ import java.util.Set;
 @Getter
 @Setter
 public class StatusRequest {
-    private String previousStatus;
-    private String currentStatus;
+    private String status;
     private String requestUrl;
     private Set<String> boardRef;
 }

--- a/src/main/java/com/thullo/web/payload/request/StatusRequest.java
+++ b/src/main/java/com/thullo/web/payload/request/StatusRequest.java
@@ -1,0 +1,16 @@
+package com.thullo.web.payload.request;
+
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Set;
+
+@Getter
+@Setter
+public class StatusRequest {
+    private String previousStatus;
+    private String currentStatus;
+    private String requestUrl;
+    private Set<String> boardRef;
+}

--- a/src/main/java/com/thullo/web/payload/request/StatusRequest.java
+++ b/src/main/java/com/thullo/web/payload/request/StatusRequest.java
@@ -4,12 +4,16 @@ package com.thullo.web.payload.request;
 import lombok.Getter;
 import lombok.Setter;
 
+import javax.validation.constraints.NotBlank;
 import java.util.Set;
 
 @Getter
 @Setter
 public class StatusRequest {
+    @NotBlank(message = "This field cannot be blank")
     private String status;
     private String requestUrl;
+
+    @NotBlank(message = "This field cannot be blank")
     private Set<String> boardRef;
 }

--- a/src/test/java/com/thullo/service/AuthServiceImplTest.java
+++ b/src/test/java/com/thullo/service/AuthServiceImplTest.java
@@ -155,7 +155,6 @@ class AuthServiceImplTest {
 
         //When
         String expected = passwordRequest.getOldPassword();
-        String actual = mockedUser.getPassword();
         authService.saveResetPassword(passwordRequest);
 
         //Assert

--- a/src/test/java/com/thullo/service/BoardServiceImplTest.java
+++ b/src/test/java/com/thullo/service/BoardServiceImplTest.java
@@ -46,7 +46,7 @@ class BoardServiceImplTest {
         board.setUser(new User());
 
         boardRequest = new BoardRequest();
-        boardRequest.setName("Test Board Update");
+        boardRequest.setBoardName("Test Board Update");
         boardRequest.setBoardVisibility("PRIVATE");
         boardRequest.setBoardTag("TES");
 
@@ -59,7 +59,7 @@ class BoardServiceImplTest {
 
         doAnswer(invocation -> {
             mapper.map(boardRequest, board);
-            board.setName(boardRequest.getName()); // Update the board name before saving
+            board.setName(boardRequest.getBoardName()); // Update the board name before saving
             return board;
         }).when(boardRepositoryMock).save(board);
 
@@ -90,7 +90,7 @@ class BoardServiceImplTest {
 
         doAnswer(invocation -> {
             mapper.map(boardRequest, board);
-            board.setName(boardRequest.getName()); // Update the board name before saving
+            board.setName(boardRequest.getBoardName()); // Update the board name before saving
             return board;
         }).when(boardRepositoryMock).save(board);
 


### PR DESCRIPTION
## Pull Request Description
I implemented an API endpoint to edit Task Status.

## Related Issue
(https://thullo.atlassian.net/jira/software/c/projects/THULLO/boards/1?modal=detail&selectedIssue=THULLO-100)

## Changes Made
I added a Put Method to the Task controller that takes previousStatus, currentStatus, boardTag and boardRef, to update the Status. 

I implemented two methods to updating the Task Status which I would hope on your feedback to pick whichever implementation suits our use case more appropriately.

The first method uses the previousStatus, boardTag to search the TaskRepository which returns a List of tasks, then I looped through the list of tasks setting each task to the currentStatus and finally saving the updated Task back to the TaskRepository, and finally returning the List of updated Tasks back to the controller. This method replaces all previousStatus on that board with the currentStatus which could have a potential bug if the TaskStatus are not distinct.

The Second Implementation takes the boardTag, currentStatus, and a set of boardRef. Then I looped through the TaskRepository findByBoardRef and then setting all the occurenece of the passed boardRef to the currentStatus and finally returning the List of updated Tasks back to the controller. 

## Checklist
- [x] I have followed the project's code style guidelines
- [x] My code builds without any errors or warnings
- [x] My changes do not introduce any new linting errors or warnings