### PR TITLE
THULLO-107: API Implementation to Delete Status

### DIFF
--- a/src/main/java/com/thullo/service/TaskService.java
+++ b/src/main/java/com/thullo/service/TaskService.java
@@ -38,5 +38,6 @@ public interface TaskService {
     void deleteAttachmentFromTask(String fileId, Long attachmentId);
 
     List<Task> editStatus(StatusRequest request) throws ResourceNotFoundException;
+    List<Task> deleteStatus(StatusRequest statusRequest) throws ResourceNotFoundException;
 }
 

--- a/src/main/java/com/thullo/service/TaskServiceImpl.java
+++ b/src/main/java/com/thullo/service/TaskServiceImpl.java
@@ -223,7 +223,7 @@ public class TaskServiceImpl implements TaskService {
 
     @Override
     public List<Task> deleteStatus(StatusRequest statusRequest) throws ResourceNotFoundException {
-        statusRequest.setStatus(formatStatus("NO_STATUS"));
+        statusRequest.setStatus("NO_STATUS");
         return editStatus(statusRequest);
     }
 

--- a/src/main/java/com/thullo/service/TaskServiceImpl.java
+++ b/src/main/java/com/thullo/service/TaskServiceImpl.java
@@ -221,6 +221,12 @@ public class TaskServiceImpl implements TaskService {
         return taskRepository.saveAll(tasks);
     }
 
+    @Override
+    public List<Task> deleteStatus(StatusRequest statusRequest) throws ResourceNotFoundException {
+        statusRequest.setStatus(formatStatus("NO_STATUS"));
+        return editStatus(statusRequest);
+    }
+
     private List<Task> getAllByBoardAndStatus(Board board, String formattedStatus) {
         return taskRepository.findAllByBoardAndStatus(board, formattedStatus);
     }

--- a/src/main/java/com/thullo/web/controller/TaskController.java
+++ b/src/main/java/com/thullo/web/controller/TaskController.java
@@ -183,4 +183,18 @@ public class TaskController {
             return ResponseEntity.badRequest().body(new ApiResponse(false, exception.getMessage()));
         }
     }
+
+    @PutMapping("{boardTag}/delete-status")
+    @PreAuthorize("@boardServiceImpl.hasBoardRole(authentication.principal.email, #boardTag) or hasRole('BOARD_' + #boardTag) or hasRole('TASK_' + #boardRef)")
+    public ResponseEntity<ApiResponse> deleteStatus(@PathVariable String boardTag,
+                                                  @RequestBody StatusRequest status,
+                                                  HttpServletRequest request) {
+        try {
+            status.setRequestUrl(request.getRequestURL().toString());
+            List<Task> tasks = taskService.deleteStatus(status);
+            return ResponseEntity.ok(new ApiResponse(true, "Status is successfully updated", tasks));
+        } catch (ResourceNotFoundException exception) {
+            return ResponseEntity.badRequest().body(new ApiResponse(false, exception.getMessage()));
+        }
+    }
 }

--- a/src/main/java/com/thullo/web/controller/TaskController.java
+++ b/src/main/java/com/thullo/web/controller/TaskController.java
@@ -192,7 +192,7 @@ public class TaskController {
         try {
             status.setRequestUrl(request.getRequestURL().toString());
             List<Task> tasks = taskService.deleteStatus(status);
-            return ResponseEntity.ok(new ApiResponse(true, "Status is successfully updated", tasks));
+            return ResponseEntity.ok(new ApiResponse(true, "Status is successfully deleted", tasks));
         } catch (ResourceNotFoundException exception) {
             return ResponseEntity.badRequest().body(new ApiResponse(false, exception.getMessage()));
         }


### PR DESCRIPTION
## Pull Request Description
I implemented an API endpoint to delete Task Status

## Related Issue
(https://thullo.atlassian.net/jira/software/c/projects/THULLO/boards/1?modal=detail&selectedIssue=THULLO-107)

## Changes Made
I added a PutMapping("{boardTag}/delete-status") to the Task controller. This controller takes the list of boardRef within the status to be deleted and also the boardTag as path variable. 
This controller calls the deleteStatus method in the Task Service implementation which sets the status as NO_STATUS and calls the editStatus method to persist the changes made on the status and on the Board which then return the updated Board to the controller.

## Checklist
- [x] I have followed the project's code style guidelines
- [x] I have added/updated tests for my changes
- [x] My code builds without any errors or warnings
- [x] My changes do not introduce any new linting errors or warnings
